### PR TITLE
Add sleep for waiting GitHub Release creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,8 @@ create-release:
 	full_version="v$$(cat VERSION)" && \
 	notes="- Release $${full_version}" && \
 	gh release create "$${full_version}" --notes "$${notes}" --draft && \
+	echo "Wait GitHub Release creation..." && \
+	sleep 3 && \
 	gh release view "$${full_version}" --web
 
 bump: input-version docs commit create-pr ## bump version


### PR DESCRIPTION
Opening in the browser immediately after a release creation may occur an error.
